### PR TITLE
Render monster cards before img has loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-promise": "^0.5.3",
-    "request": "^2.83.0",
     "semantic-ui-react": "^0.77.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "body-parser": "^1.17.2",
     "cheerio": "^1.0.0-rc.2",
     "express": "^4.15.0",
@@ -34,6 +35,7 @@
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-promise": "^0.5.3",
+    "request": "^2.83.0",
     "semantic-ui-react": "^0.77.1"
   }
 }

--- a/react-client/src/actions/index.js
+++ b/react-client/src/actions/index.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 export const CHANGE_TAB = 'CHANGE_TAB';
 export const ADD_MONSTER = 'ADD_MONSTER';
 export const DELETE_MONSTER = 'DELETE_MONSTER';
+export const ADD_MONSTER_IMG = 'ADD_MONSTER_IMG';
 
 export const populateMonsterUrls = () => {
   axios('http://www.dnd5eapi.co/api/monsters')
@@ -16,21 +17,22 @@ export const populateMonsterUrls = () => {
 };
 
 export const addMonster = (url, checked) => {
+  let monsterId;
   axios.get(url)
   .then(res => {
     const monster = res.data;
+    monsterId = monster._id;
     if (checked) {
       monster.init = Math.floor((monster.dexterity - 10) / 2) + (Math.floor(Math.random() * Math.floor(20)));
-      store.dispatch({type: 'ADD_MONSTER', payload: monster});
+      store.dispatch({type: ADD_MONSTER, payload: monster});
     } else {
-      store.dispatch({type: 'ADD_MONSTER', payload: monster});
+      store.dispatch({type: ADD_MONSTER, payload: monster});
     }
 
     fetchMonsterImg(monster.name)
     .then(url => {
-      console.log(url);
+        addMonsterImg(url, monsterId);
     });
-
   });
 }
 
@@ -43,9 +45,15 @@ const fetchMonsterImg = monsterName => {
   .then(res => res.data);
 };
 
-// export const addMonsterImg = url => {
-
-// };
+const addMonsterImg = (url, monsterId) => {
+  store.dispatch({
+    type: ADD_MONSTER_IMG,
+    payload: {
+      url: url,
+      id: monsterId
+    }
+  });
+};
 
 export const removeMonster = monster => {
   return {

--- a/react-client/src/actions/index.js
+++ b/react-client/src/actions/index.js
@@ -1,5 +1,6 @@
 import store from '../store';
 import $ from 'jquery';
+import axios from 'axios';
 
 export const CHANGE_TAB = 'CHANGE_TAB';
 export const ADD_MONSTER = 'ADD_MONSTER';
@@ -15,23 +16,38 @@ export const populateMonsterUrls = () => {
 };
 
 export const addMonster = (url, checked) => {
-  $.get(url)
-    .then(monster => {
-      $.get('http://localhost:3000/monsterimg', {monsterName: monster.name})
-        .then(res => {
-          monster.image = res;
-          if (checked) {
-            monster.init = Math.floor((monster.dexterity - 10) / 2) + (Math.floor(Math.random() * Math.floor(20)));
-            store.dispatch({type: 'ADD_MONSTER', payload: monster});
-          } else {
-            store.dispatch({type: 'ADD_MONSTER', payload: monster});
-          }
-        });
+  axios.get(url)
+  .then(res => {
+    const monster = res.data;
+    if (checked) {
+      monster.init = Math.floor((monster.dexterity - 10) / 2) + (Math.floor(Math.random() * Math.floor(20)));
+      store.dispatch({type: 'ADD_MONSTER', payload: monster});
+    } else {
+      store.dispatch({type: 'ADD_MONSTER', payload: monster});
+    }
+
+    fetchMonsterImg(monster.name)
+    .then(url => {
+      console.log(url);
     });
+
+  });
 }
 
+const fetchMonsterImg = monsterName => {
+  return axios.get('http://localhost:3000/monsterimg', {
+    params: {
+      monsterName: monsterName
+    }
+  })
+  .then(res => res.data);
+};
 
-export const removeMonster = (monster) => {
+// export const addMonsterImg = url => {
+
+// };
+
+export const removeMonster = monster => {
   return {
     type: DELETE_MONSTER,
     payload: monster
@@ -44,7 +60,7 @@ export const generateTurnOrder = () => {
   }
 }
 
-export const selectTab = (tab) => {
+export const selectTab = tab => {
   return {
     type: CHANGE_TAB,
     payload: tab

--- a/react-client/src/actions/index.js
+++ b/react-client/src/actions/index.js
@@ -1,5 +1,4 @@
 import store from '../store';
-import $ from 'jquery';
 import axios from 'axios';
 
 export const CHANGE_TAB = 'CHANGE_TAB';
@@ -7,10 +6,11 @@ export const ADD_MONSTER = 'ADD_MONSTER';
 export const DELETE_MONSTER = 'DELETE_MONSTER';
 
 export const populateMonsterUrls = () => {
-  $.get('http://www.dnd5eapi.co/api/monsters', (res) => {
+  axios('http://www.dnd5eapi.co/api/monsters')
+  .then(res => {
     store.dispatch({
       type: 'POPULATE_MONSTER_URLS',
-      payload: res.results
+      payload: res.data.results
     });
   });
 };

--- a/react-client/src/reducers/monstersReducer.js
+++ b/react-client/src/reducers/monstersReducer.js
@@ -1,9 +1,14 @@
 const monstersReducer = (state = [], action) => {
   if (action.type === 'ADD_MONSTER') {
     return [...state, action.payload];
+
   } else if (action.type === 'DELETE_MONSTER') {
-      const index = state.findIndex(monster => monster.name === action.payload.name);
-      return [...state.slice(0, index), ...state.slice(index + 1)];
+    const index = state.findIndex(monster => monster.name === action.payload.name);
+    return [...state.slice(0, index), ...state.slice(index + 1)];
+
+  } else if (action.type === 'ADD_MONSTER_IMG') {
+    const index = state.findIndex(monster => monster._id === action.payload.id);
+    return [...state.slice(0, index), ...state.slice(index + 1), {...state[index], image: action.payload.url}];
   }
   return state;
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var db = require('../database-mongo');
-var request = require('request');
+var axios = require('axios');
 var cheerio = require('cheerio');
 
 var app = express();
@@ -13,11 +13,14 @@ app.listen(3000, function() {
   console.log('listening on port 3000!');
 });
 
-app.get('/monsterimg', (req, res) => {
+app.get('/monsterimg', (req, res1) => {
   const monsterPath = req.query.monsterName.split(' ').join('-');
-  request(`https://www.dndbeyond.com/monsters/${monsterPath}`, (err, scrapeRes, body) => {
-    const $ = cheerio.load(body);
-    const imgUrl = $('.monster-image').attr('src');
-    res.send(imgUrl);
+  axios.get(`https://www.dndbeyond.com/monsters/${monsterPath}`)
+  .then(res2 => {
+    const html = res2.data;
+    const $ = cheerio.load(html);
+    const imgSrc = $('.monster-image').attr('src');
+    console.log(imgSrc);
+    res1.send(imgSrc);
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,10 @@
-var express = require('express');
-var bodyParser = require('body-parser');
-var db = require('../database-mongo');
-var axios = require('axios');
-var cheerio = require('cheerio');
+const express = require('express');
+const bodyParser = require('body-parser');
+const db = require('../database-mongo');
+const axios = require('axios');
+const cheerio = require('cheerio');
 
-var app = express();
+const app = express();
 
 app.use(express.static(__dirname + '/../react-client/dist'));
 
@@ -20,7 +20,6 @@ app.get('/monsterimg', (req, res1) => {
     const html = res2.data;
     const $ = cheerio.load(html);
     const imgSrc = $('.monster-image').attr('src');
-    console.log(imgSrc);
     res1.send(imgSrc);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,7 +3902,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@^2.83.0:
+request@2:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1446,6 +1453,12 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1825,6 +1838,12 @@ flux-standard-action@^0.6.1:
   resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-0.6.1.tgz#6f34211b94834ea1c3cc30f4e7afad3d0fbf71a2"
   dependencies:
     lodash.isplainobject "^3.2.0"
+
+follow-redirects@^1.2.5:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.3.0.tgz#f684871fc116d2e329fda55ef67687f4fabc905c"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -3883,7 +3902,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2:
+request@2, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:


### PR DESCRIPTION
Improve UX by providing instant feedback when a monster is added, instead of waiting multiple seconds for it's image to load before anything is rendered on the page.

Also, replace `request` and most `jquery` dependency with `axios`.