### PR TITLE
Fix rendering on duplicate monsters

### DIFF
--- a/react-client/src/actions/index.js
+++ b/react-client/src/actions/index.js
@@ -17,11 +17,9 @@ export const populateMonsterUrls = () => {
 };
 
 export const addMonster = (url, checked) => {
-  let monsterId;
   axios.get(url)
   .then(res => {
     const monster = res.data;
-    monsterId = monster._id;
     if (checked) {
       monster.init = Math.floor((monster.dexterity - 10) / 2) + (Math.floor(Math.random() * Math.floor(20)));
       store.dispatch({type: ADD_MONSTER, payload: monster});
@@ -31,7 +29,7 @@ export const addMonster = (url, checked) => {
 
     fetchMonsterImg(monster.name)
     .then(url => {
-        addMonsterImg(url, monsterId);
+        addMonsterImg(url, monster.name);
     });
   });
 }
@@ -45,12 +43,12 @@ const fetchMonsterImg = monsterName => {
   .then(res => res.data);
 };
 
-const addMonsterImg = (url, monsterId) => {
+const addMonsterImg = (url, monsterName) => {
   store.dispatch({
     type: ADD_MONSTER_IMG,
     payload: {
       url: url,
-      id: monsterId
+      name: monsterName
     }
   });
 };

--- a/react-client/src/actions/index.js
+++ b/react-client/src/actions/index.js
@@ -29,7 +29,7 @@ export const addMonster = (url, checked) => {
 
     fetchMonsterImg(monster.name)
     .then(url => {
-        addMonsterImg(url, monster.name);
+        addMonsterImg(url, monster.id);
     });
   });
 }
@@ -43,20 +43,22 @@ const fetchMonsterImg = monsterName => {
   .then(res => res.data);
 };
 
-const addMonsterImg = (url, monsterName) => {
+const addMonsterImg = (url, id) => {
   store.dispatch({
     type: ADD_MONSTER_IMG,
     payload: {
       url: url,
-      name: monsterName
+      id: id
     }
   });
 };
 
-export const removeMonster = monster => {
+export const removeMonster = id => {
   return {
     type: DELETE_MONSTER,
-    payload: monster
+    payload: {
+      id: id
+    }
   }
 }
 

--- a/react-client/src/containers/MonstersList.js
+++ b/react-client/src/containers/MonstersList.js
@@ -52,7 +52,7 @@ class MonstersList extends Component {
                             More monster info
                           </a>
                           <Icon
-                          onClick={() => {this.props.removeMonster(monster)}} 
+                          onClick={() => {this.props.removeMonster(monster.id)}} 
                           className='deleteMonsterIcon' 
                           color='red' 
                           name='remove'/>

--- a/react-client/src/reducers/monstersReducer.js
+++ b/react-client/src/reducers/monstersReducer.js
@@ -1,13 +1,14 @@
 const monstersReducer = (state = [], action) => {
   if (action.type === 'ADD_MONSTER') {
+    action.payload.id = action.payload._id.concat(state.length);
     return [...state, action.payload];
 
   } else if (action.type === 'DELETE_MONSTER') {
-    const index = state.findIndex(monster => monster.name === action.payload.name);
+    const index = state.findIndex(monster => monster.id === action.payload.id);
     return [...state.slice(0, index), ...state.slice(index + 1)];
 
   } else if (action.type === 'ADD_MONSTER_IMG') {
-    const index = state.findIndex(monster => monster.name === action.payload.name);
+    const index = state.findIndex(monster => monster.id === action.payload.id);
     return [...state.slice(0, index), {...state[index], image: action.payload.url}, ...state.slice(index + 1)];
   }
   return state;

--- a/react-client/src/reducers/monstersReducer.js
+++ b/react-client/src/reducers/monstersReducer.js
@@ -7,8 +7,8 @@ const monstersReducer = (state = [], action) => {
     return [...state.slice(0, index), ...state.slice(index + 1)];
 
   } else if (action.type === 'ADD_MONSTER_IMG') {
-    const index = state.findIndex(monster => monster._id === action.payload.id);
-    return [...state.slice(0, index), ...state.slice(index + 1), {...state[index], image: action.payload.url}];
+    const index = state.findIndex(monster => monster.name === action.payload.name);
+    return [...state.slice(0, index), {...state[index], image: action.payload.url}, ...state.slice(index + 1)];
   }
   return state;
 };


### PR DESCRIPTION
Make monster image rendering and monster deletion dependent on unique monster ids (created with every new monster added).